### PR TITLE
Set vim-stripper to ignore SQL files

### DIFF
--- a/vimrc_main
+++ b/vimrc_main
@@ -873,8 +873,8 @@ let g:buffergator_suppress_keymaps=1
 let g:buffergator_sort_regime = "mru"
 map <Leader>b :BuffergatorToggle<cr>
 
-" Vim-stripper
-let g:StripperIgnoreFileTypes = []
+" Vim-stripper: Stripe whitespace from the end of lines for all except .sql
+let g:StripperIgnoreFileTypes = ['sql']
 
 " reload current top window/tab of chrome
 map <leader>rr :ChromeReload<CR>


### PR DESCRIPTION
I've encountered trouble in the past where whitespace was necessary at EOL in SQL scripts to properly populate values in Postgres. This PR configures `vim-stripper` to skip any `.sql` files when cleaning up whitespace.